### PR TITLE
Make tegola config generator more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The mapping file controls how the OSM subset is imported with
 [imposm3](https://imposm.org/docs/imposm3/latest/). It's generated from the files in [mapping](mapping)
 by calling `python3 ./mapping/main.py > ./mapping.json`.
 
-The `layers.yml` file is used to generate the Tegola config using
-`python3 ./tegola/generate_tegola_config.py ./tegola/layers.yml > ./config.toml`.
+The `tegola.yml` and `layers.yml` files are used to generate the Tegola config using
+`python3 ./tegola/generate_tegola_config.py ./tegola/tegola.yml ./tegola/layers.yml > ./tegola/config.toml`.
 
 ## Services
 
@@ -15,7 +15,7 @@ Imposm runs as a service with the `-expiretiles-dir` option:
 
 The low-zoom layers are seeded daily with:
 
-	/usr/local/bin/tegola cache seed --bounds="-180,-85.0511,180,85.0511" --min-zoom 2 --max-zoom 6 --overwrite --config /home/osm/styles/config.toml
+	/usr/local/bin/tegola cache seed --bounds="-180,-85.0511,180,85.0511" --min-zoom 2 --max-zoom 6 --overwrite --config /home/osm/styles/tegola/config.toml
 
 Invalidated tiles are removed every minute:
 

--- a/tegola/expire.py
+++ b/tegola/expire.py
@@ -23,7 +23,7 @@ for path in pathlist:
             "tile-list",
             path,
             "--config",
-            "/home/osm/styles/config.toml",
+            "/home/osm/styles/tegola/config.toml",
             "--max-zoom",
             "17",
             "--min-zoom",

--- a/tegola/layers.yml
+++ b/tegola/layers.yml
@@ -202,7 +202,8 @@ layers:
     where: type = 'switch' AND geometry && !BBOX! AND !ZOOM! >= 14
 
   - name: power_heatmap_solar
-    map: solar_heatmap
+    map: 
+      - solar_heatmap
     geometry_type: Point
     min_zoom: 2
     id_field: gid

--- a/tegola/tegola.yml
+++ b/tegola/tegola.yml
@@ -1,0 +1,17 @@
+webserver:
+  port: 8081
+
+cache: 
+  type: file
+  basepath: /tmp/tegola
+
+providers:
+  - name: postgis
+    type: mvt_postgis
+    host: 10.43.18.68
+    port: 5432
+    database: osm
+    user: osm
+    password: osm
+    srid: 3857
+    max_connections: 20


### PR DESCRIPTION
Hi Russss, this PR to make Tegola config generator more generic and allow to build several tegola configs on the same project.

It involves an additional tegola.yml file to use different cache paths, different ports and different db if required.

It allows to use a layer in several map as well with layers.yml like:
```
- name: power_line
    map:
      - openinframap
      - gespot
```