### PR TITLE
Fix osmose-power translation key

### DIFF
--- a/web/src/openinframap.ts
+++ b/web/src/openinframap.ts
@@ -73,7 +73,7 @@ export default class OpenInfraMap {
           new Layer('W', t('layers.water'), 'water_', false)
         ]),
         new LayerGroup(t('layers.validation'), [
-          new Layer('E', t('layers.power'), 'osmose_errors_power', false)
+          new Layer('E', t('layers.osmose-power'), 'osmose_errors_power', false)
         ])
       ],
       t('layers.title', 'Layers')


### PR DESCRIPTION
In [6b26c1](https://github.com/openinframap/openinframap/commit/6b26c1d08c04765e43bbb46dbcfc25eec42095f7) you add `layers.osmose-power` in `translation.json` but you use `layers.power` in `openinframap.ts`.

This PR propose to use `layers.osmose-power` but we can also remove the unused translation key if you prefer.