### PR TITLE
Filtering by data centers

### DIFF
--- a/web/locales/en/translation.json
+++ b/web/locales/en/translation.json
@@ -215,6 +215,7 @@
     "power": "Power",
     "solar-generation": "Solar Generation",
     "telecoms": "Telecoms",
+    "data-centers": "Data Centers",
     "petroleum": "Oil & Natural Gas",
     "water": "Water",
     "borders": "Borders",

--- a/web/src/openinframap.ts
+++ b/web/src/openinframap.ts
@@ -68,6 +68,7 @@ export default class OpenInfraMap {
         new LayerGroup(t('layers.infrastructure'), [
           new Layer('P', t('layers.power'), 'power_', true),
           new Layer('T', t('layers.telecoms'), 'telecoms_', false),
+          new Layer('D', t('layers.data-centers'), 'telecoms_data_', false),
           new Layer('O', t('layers.petroleum'), 'petroleum_', false),
           new Layer('I', t('layers.other-pipelines'), 'pipeline_', false),
           new Layer('W', t('layers.water'), 'water_', false)


### PR DESCRIPTION
This PR proposal is related to this #260 

To achieve this I modified 2 files in the web directory:
* locales/en/translation.json: Adding the data-centers key in layers group
* src/openinframap.ts: Adding a new Layer in Infrastructure LayerGroup

**Result**:
<img width="431" height="947" alt="image" src="https://github.com/user-attachments/assets/b9e05593-4aa0-49fe-b0fe-412486683575" />

**Remark**:
When I try to change the order of the layers, for example by moving Datacenters before Telecoms, the filter stops working.