### PR TITLE
Improve imposm mapping

### DIFF
--- a/imposm/main.py
+++ b/imposm/main.py
@@ -1,6 +1,8 @@
 import json
 from funcs import tables, generalized_tables
 
+import utility  # noqa
+import pipeline  # noqa
 import power  # noqa
 import telecoms  # noqa
 import petroleum  # noqa

--- a/imposm/petroleum.py
+++ b/imposm/petroleum.py
@@ -1,24 +1,6 @@
 from funcs import table, type_col, str_col
 
 table(
-    "marker",
-    {"pipeline": ["marker"], "power": ["marker"], "marker": ["__any__"]},
-    "point",
-    columns=[type_col],
-)
-
-table(
-    "pipeline",
-    {"man_made": ["pipeline"], "construction:man_made": ["pipeline"]},
-    "linestring",
-    columns=[
-        str_col("substance"),
-        str_col("type"),
-        str_col("construction:man_made", "construction"),
-    ],
-)
-
-table(
     "petroleum_site",
     {
         "industrial": [
@@ -39,14 +21,11 @@ table(
         "pipeline": ["substation"],
     },
     "polygon",
-    columns=[type_col, str_col("name")],
-)
-
-table(
-    "pipeline_feature",
-    {"pipeline": ["valve", "flare"]},
-    "point",
-    columns=[type_col],
+    columns=[
+        type_col,
+        str_col("name"),
+        str_col("utility")
+    ],
 )
 
 table(

--- a/imposm/pipeline.py
+++ b/imposm/pipeline.py
@@ -1,0 +1,100 @@
+from funcs import (
+    table,
+    str_col,
+    type_col,
+)
+
+table(
+    "pumping_station",
+    {
+        "man_made": ["pumping_station"],
+        "construction:man_made": ["pumping_station"],
+        "disused:man_made": ["pumping_station"]
+    },
+    "polygon",
+    columns=[
+        str_col("name"),
+        str_col("pumping_station"),
+        str_col("utility"),
+        str_col("substance"),
+        str_col("construction:man_made", "construction"),
+        str_col("disused:man_made", "disused")
+    ]
+)
+
+table(
+    "pipeline",
+    {
+        "man_made": ["pipeline"],
+        "construction:man_made": ["pipeline"],
+        "disused:man_made": ["pipeline"]
+    },
+    "linestring",
+    columns=[
+        str_col("substance"),
+        str_col("type"),
+        str_col("construction:man_made", "construction"),
+        str_col("disused:man_made", "disused"),
+    ],
+)
+
+table(
+    "pipeline_feature",
+    {"pipeline": ["valve", "flare", "surge_tank"]},
+    "point",
+    columns=[
+        str_col("valve"),
+        str_col("actuator"),
+        str_col("handle"),
+        str_col("operator"),
+        type_col
+    ],
+)
+
+table(
+    "pipeline_pump",
+    {"man_made": ["pump"]},
+    "point",
+    columns=[
+        type_col,
+        str_col("pump_mechanism"),
+        str_col("mechanical_driver"),
+        str_col("mechanical_coupling"),
+        str_col("handle"),
+        str_col("operator"),
+        str_col("substance"),
+        str_col("flow_rate"),
+        str_col("pressure")
+    ],
+)
+
+table(
+    "inlets",
+    {"inlet": ["__any__"]},
+    "point",
+    columns=[
+        type_col,
+        str_col("name"),
+        str_col("operator"),
+        str_col("diameter"),
+        str_col("substance"),
+        str_col("flow_rate")
+    ],
+)
+
+table(
+    "outlets",
+    {
+        "outlet": ["__any__"],
+        "man_made": ["outfall"],
+    },
+    "point",
+    columns=[
+        type_col,
+        str_col("name"),
+        str_col("operator"),
+        str_col("diameter"),
+        str_col("substance"),
+        str_col("flow_rate")
+    ],
+)

--- a/imposm/power.py
+++ b/imposm/power.py
@@ -83,6 +83,7 @@ table(
     {
         "power": ["substation"],
         "construction:power": ["substation"],
+        "disused:power": ["substation"],
     },
     ["points", "polygons"],
     columns=[
@@ -91,6 +92,7 @@ table(
         str_col("voltage"),
         str_col("frequency"),
         str_col("construction:power", "construction"),
+        str_col("disused:power", "disused"),
         bool_col("tunnel"),
     ],
 )
@@ -100,6 +102,7 @@ relation_tables(
     {
         "power": ["substation"],
         "construction:power": ["substation"],
+        "disused:power": ["substation"],
     },
     relation_types=["site"],
     relation_columns=[
@@ -107,6 +110,7 @@ relation_tables(
         str_col("voltage"),
         str_col("frequency"),
         str_col("construction:power", "construction"),
+        str_col("disused:power", "disused"),
         bool_col("tunnel"),
     ],
 )
@@ -131,29 +135,43 @@ table(
 
 table(
     "power_plant",
-    {"power": ["plant"], "construction:power": ["plant"]},
+    {
+        "power": ["plant"],
+        "construction:power": ["plant"],
+        "disused:power": ["plant"]
+    },
     "polygon",
     columns=[
         str_col("plant:output:electricity", "output"),
         str_col("plant:source", "source"),
         str_col("construction:power", "construction"),
+        str_col("disused:power", "disused"),
     ],
 )
 
 relation_tables(
     "power_plant_relation",
-    {"power": ["plant"], "construction:power": ["plant"]},
+    {
+        "power": ["plant"],
+        "construction:power": ["plant"],
+        "disused:power": ["plant"]
+    },
     ["site"],
     relation_columns=[
         str_col("plant:output:electricity", "output"),
         str_col("plant:source", "source"),
         str_col("construction:power", "construction"),
+        str_col("disused:power", "disused"),
     ],
 )
 
 table(
     "power_generator",
-    {"power": ["generator"], "construction:power": ["generator"]},
+    {
+        "power": ["generator"],
+        "construction:power": ["generator"],
+        "disused:power": ["disused"]
+    },
     ["points", "polygons"],
     columns=[
         str_col("generator:source", "source"),
@@ -161,5 +179,6 @@ table(
         str_col("generator:type", "type"),
         str_col("generator:output:electricity", "output"),
         str_col("construction:power", "construction"),
+        str_col("disused:power", "disused"),
     ],
 )

--- a/imposm/telecoms.py
+++ b/imposm/telecoms.py
@@ -6,8 +6,13 @@ table(
     {
         "communication": ["line", "cable"],
         "construction:communication": ["line", "cable"],
+        "disused:communication": ["line", "cable"],
     },
     "linestring",
+    columns=[
+        type_col,
+        str_col("telecom:medium")
+    ]
 )
 
 table(
@@ -17,16 +22,24 @@ table(
         "telecom": ["data_center", "data_centre", "central_office", "exchange"],
         "office": ["telecommunication"],
         "man_made": ["telephone_office"],
+        "construction:telecom": ["data_center", "data_centre", "central_office", "exchange"],
+        "disused:telecom": ["data_center", "data_centre", "central_office", "exchange"]
     },
     ["points", "polygons"],
-    columns=[type_col],
+    columns=[
+        type_col,
+        str_col("telecom:medium")
+    ],
 )
 
 table(
     "telecom_location",
     {"telecom": ["connection_point", "distribution_point"]},
     ["points", "polygons"],
-    columns=[type_col],
+    columns=[
+        type_col,
+        str_col("telecom:medium")
+    ],
 )
 
 table(
@@ -46,18 +59,4 @@ table(
     },
     ["points", "polygons"],
     columns=[type_col],
-)
-
-table(
-    "utility_pole",
-    {"man_made": ["utility_pole"]},
-    "point",
-    columns=[str_col("utility")],
-)
-
-table(
-    "street_cabinet",
-    {"man_made": ["street_cabinet"]},
-    ["points", "polygons"],
-    columns=[str_col("utility")],
 )

--- a/imposm/utility.py
+++ b/imposm/utility.py
@@ -1,0 +1,51 @@
+from funcs import (
+    table,
+    str_col,
+    bool_col,
+    type_col,
+)
+
+table(
+    "utility_pole",
+    {
+        "man_made": ["utility_pole"],
+        "construction:man_made": ["utility_pole"],
+        "disused:man_made": ["utility_pole"]
+    },
+    "point",
+    columns=[
+        type_col,
+        bool_col("location:transition", "transition"),
+        str_col("construction:man_made", "construction"),
+        str_col("disused:man_made", "disused")
+    ]
+)
+
+table(
+    "utility_marker",
+    {"marker": ["__any__"]},
+    "point",
+    columns=[
+        str_col("utility"),
+        str_col("colour"),
+        str_col("material"),
+        str_col("operator"),
+        type_col
+    ]
+)
+
+table(
+    "street_cabinet",
+    {
+        "man_made": ["street_cabinet"],
+        "construction:man_made": ["street_cabinet"],
+        "disused:man_made": ["street_cabinet"]
+    },
+    ["points", "polygons"],
+    columns=[
+        str_col("utility"),
+        str_col("street_cabinet"),
+        str_col("construction:man_made", "construction"),
+        str_col("disused:man_made", "disused")
+    ]
+)

--- a/imposm/water.py
+++ b/imposm/water.py
@@ -2,28 +2,37 @@ from funcs import table, type_col, str_col
 
 table(
     "water_treatment_plant",
-    {"man_made": ["water_works", "desalination_plant"]},
+    {
+        "man_made": ["water_works", "desalination_plant"],
+        "construction:man_made": ["water_works", "desalination_plant"],
+        "disused:man_made": ["water_works", "desalination_plant"]
+    },
     "polygon",
     columns=[type_col, str_col("name")],
 )
 
 table(
     "wastewater_plant",
-    {"man_made": ["wastewater_plant"]},
+    {
+        "man_made": ["wastewater_plant"],
+        "construction:man_made": ["wastewater_plant"],
+        "disused:man_made": ["wastewater_plant"]
+    },
     "polygon",
     columns=[type_col, str_col("name")],
 )
 
-table(
-    "pumping_station",
-    {"man_made": ["pumping_station"]},
-    "polygon",
-    columns=[str_col("name"), str_col("pumping_station"), str_col("substance")],
-)
+table("water_tower", {
+    "man_made": ["water_tower"],
+    "construction:man_made": ["water_tower"],
+    "disused:man_made": ["water_tower"]
+}, ["points", "polygons"])
 
-table("water_tower", {"man_made": ["water_tower"]}, ["points", "polygons"])
-
-table("water_well", {"man_made": ["water_well"]}, ["points", "polygons"])
+table("water_well", {
+    "man_made": ["water_well"],
+    "construction:man_made": ["water_well"],
+    "disused:man_made": ["water_well"],
+}, ["points", "polygons"])
 
 table(
     "pressurised_waterway",
@@ -34,7 +43,10 @@ table(
 
 table(
     "water_reservoir",
-    {"man_made": ["reservoir_covered"], "water": ["reservoir"]},
+    {
+        "man_made": ["reservoir_covered"],
+        "water": ["reservoir"]
+    },
     "polygon",
     columns=[type_col, str_col("name")],
 )


### PR DESCRIPTION
I propose several improvements in imposm mapping:
- Group utility features in utility.py (utility poles, markers and street cabinets) see #32 
- Group pipeline features in pipeline.py, add support for outfalls/inlets/outlets see #192 
- Remove corresponding features from petroleum, water and telecoms
- Generalise disused:* on facilities (power substations, plants and generators, water works, future-proof telecoms features) see #201
- Add support for pipeline pumps
- Various columns add (telecom:medium for telecoms, utility for petroleum sites)

Some existing tables are renamed:
- marker => utility_marker

No impact on styles nor tegola

Merging this will require reimport but improve maintenance and add support for wider set of features